### PR TITLE
Add new bindingHandler type (functions) re. #663 / #1602

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@ rules:
   strict: 0
   dot-notation: 0
   no-underscore-dangle: 0
+  no-use-before-define: 0
   eol-last: 0
   curly: 0
   quotes: 0
@@ -25,3 +26,13 @@ globals:
   koExports: true
   jQueryInstance: true
   DEBUG: true
+
+  # Testing globals
+  beforeEach: true
+  testNode: true
+  it: true
+  describe: true
+  expect: true
+  iit: true
+  ddescribe: true
+  jasmine: true

--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -600,6 +600,35 @@ describe('Binding attribute syntax', function() {
             expect(yCalls).toEqual(2);
         });
 
+        it("has a .pureComputed() property with the node's lifecycle", function () {
+            var instance, calls = 0;
+            ko.bindingHandlers.fnHandler = function () {
+                instance = this;
+                this.v = ko.observable(0);
+                this.pc = this.pureComputed(this.calculate_pure);
+            };
+            ko.bindingHandlers.fnHandler.prototype = {
+                calculate_pure: function() {
+                    this.v();
+                    expect(this).toEqual(instance);
+                    calls++;
+                }
+            };
+            testNode.innerHTML = '<i data-bind="fnHandler"></i>';
+            ko.applyBindings({}, testNode);
+            expect(calls).toEqual(0);
+            instance.pc();
+            expect(calls).toEqual(1);
+            instance.v(1);
+            instance.pc();
+            expect(calls).toEqual(2);
+
+            ko.cleanNode(testNode);
+            instance.v(2);
+            instance.pc();
+            expect(calls).toEqual(2);
+        })
+
         it("has a .subscribe property with the node's lifecycle", function () {
             var obs = ko.observable(),
                 handlerInstance;

--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -534,7 +534,7 @@ describe('Binding attribute syntax', function() {
             var called = 0
             ko.bindingHandlers.fnHandler = function () { called++; };
             ko.bindingHandlers.fnHandler.prototype = {
-                allowVirtualElements: true
+                allowVirtual: true
             };
             testNode.innerHTML = '<b><!-- ko fnHandler --><!-- /ko --></b>';
             ko.applyBindings({}, testNode);
@@ -544,7 +544,7 @@ describe('Binding attribute syntax', function() {
         it("virtual elements via fn.allowVirtualElements", function () {
             var called = 0
             ko.bindingHandlers.fnHandler = function () { called++};
-            ko.bindingHandlers.fnHandler.allowVirtualElements = true;
+            ko.bindingHandlers.fnHandler.allowVirtual = true;
             testNode.innerHTML = '<b><!-- ko fnHandler --><!-- /ko --></b>';
             ko.applyBindings({}, testNode);
             expect(called).toEqual(1);

--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -493,16 +493,16 @@ describe('Binding attribute syntax', function() {
             var obj = { 'canary': 42 },
                 viewModel = {param: obj};
             ko.bindingHandlers.fnHandler = function (params) {
-                expect(params.value).toEqual(obj)
-                expect(params.element).toEqual(testNode.children[0])
-                expect(params.$data).toEqual(viewModel)
+                expect(params.value).toEqual(obj);
+                expect(params.element).toEqual(testNode.children[0]);
+                expect(params.$data).toEqual(viewModel);
                 expect(params.$context).toEqual(
-                    ko.contextFor(testNode.children[0]))
-                expect(params.allBindings()['bx']).toEqual(43)
-                expect(params.allBindings.get('bx')).toEqual(43)
+                    ko.contextFor(testNode.children[0]));
+                expect(params.allBindings()['bx']).toEqual(43);
+                expect(params.allBindings.get('bx')).toEqual(43);
             }
             testNode.innerHTML = "<p data-bind='fnHandler: param, bx: 43'>";
-            ko.applyBindings(viewModel, testNode)
+            ko.applyBindings(viewModel, testNode);
         });
 
         it("calls the `fn::dispose` when cleaned up", function () {
@@ -563,8 +563,8 @@ describe('Binding attribute syntax', function() {
         });
 
         it("has a .computed() property with the node's lifecycle", function () {
-            var instance;
-            var xCalls = 0,
+            var instance,
+                xCalls = 0,
                 yCalls = 0;
             ko.bindingHandlers.fnHandler = function () {
                 var v = this.v = ko.observable(0);
@@ -660,13 +660,13 @@ describe('Binding attribute syntax', function() {
                 this.addEventHandler('click', eventHandler);
             };
             testNode.innerHTML = "<i data-bind='fnHandler'></i>";
-            ko.applyBindings({}, testNode)
-            expect(fnCalls).toEqual(0)
-            ko.utils.triggerEvent(testNode.children[0], 'click')
-            expect(fnCalls).toEqual(1)
-            ko.cleanNode(testNode)
-            ko.utils.triggerEvent(testNode.children[0], 'click')
-            expect(fnCalls).toEqual(1)
+            ko.applyBindings({}, testNode);
+            expect(fnCalls).toEqual(0);
+            ko.utils.triggerEvent(testNode.children[0], 'click');
+            expect(fnCalls).toEqual(1);
+            ko.cleanNode(testNode);
+            ko.utils.triggerEvent(testNode.children[0], 'click');
+            expect(fnCalls).toEqual(1);
         })
     });
 });

--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -483,4 +483,140 @@ describe('Binding attribute syntax', function() {
             expect(testNode).toContainHtml('<p>replaced</p><template>test</template><p>replaced</p>');
         });
     });
+
+
+    describe("Function binding handlers", function () {
+        it("constructs the element with appropriate params", function () {
+            var obj = { 'canary': 42 },
+                viewModel = {param: obj};
+            ko.bindingHandlers.fnHandler = function (params) {
+                expect(params.value).toEqual(obj)
+                expect(params.element).toEqual(testNode.children[0])
+                expect(params.$data).toEqual(viewModel)
+                expect(params.$context).toEqual(
+                    ko.contextFor(testNode.children[0]))
+                expect(params.allBindings()['bx']).toEqual(43)
+                expect(params.allBindings.get('bx')).toEqual(43)
+            }
+            testNode.innerHTML = "<p data-bind='fnHandler: param, bx: 43'>";
+            ko.applyBindings(viewModel, testNode)
+        });
+
+        it("calls the `fn::dispose` when cleaned up", function () {
+            var viewModel = { x: ko.observable(true) },
+                instance = null,
+                disposeCalled = 0;
+            ko.bindingHandlers.fnHandler = function (params) {
+                instance = this;
+            };
+            ko.bindingHandlers.fnHandler.prototype = {
+                dispose: function () {
+                    disposeCalled++;
+                    expect(this).toEqual(instance);
+                }
+            };
+            testNode.innerHTML = '<b data-bind="if: x"><i data-bind="fnHandler"></i></b>';
+            ko.applyBindings(viewModel, testNode);
+            expect(disposeCalled).toEqual(0);
+            viewModel.x(false);
+            expect(disposeCalled).toEqual(1);
+        });
+
+        it("does not error without a `dispose` property", function () {
+            var viewModel = { x: ko.observable(true) };
+            ko.bindingHandlers.fnHandler = function (params) {};
+            testNode.innerHTML = '<b data-bind="if: x"><i data-bind="fnHandler"></i></b>';
+            ko.applyBindings(viewModel, testNode);
+            viewModel.x(false);
+        });
+
+        it("virtual elements via fn::allowVirtualElements", function () {
+            var called = 0
+            ko.bindingHandlers.fnHandler = function () { called++; };
+            ko.bindingHandlers.fnHandler.prototype = {
+                allowVirtualElements: true
+            };
+            testNode.innerHTML = '<b><!-- ko fnHandler --><!-- /ko --></b>';
+            ko.applyBindings({}, testNode);
+            expect(called).toEqual(1);
+        });
+
+        it("virtual elements via fn.allowVirtualElements", function () {
+            var called = 0
+            ko.bindingHandlers.fnHandler = function () { called++};
+            ko.bindingHandlers.fnHandler.allowVirtualElements = true;
+            testNode.innerHTML = '<b><!-- ko fnHandler --><!-- /ko --></b>';
+            ko.applyBindings({}, testNode);
+            expect(called).toEqual(1);
+        });
+
+        it("errors when allowVirtualElements is not set", function () {
+            ko.bindingHandlers.fnHandler = function () { called++; };
+            testNode.innerHTML = '<b><!-- ko fnHandler --><!-- /ko --></b>';
+
+            expect(function () {
+                ko.applyBindings({}, testNode);
+            }).toThrowContaining("The binding 'fnHandler' cannot be used with virtual elements");
+        });
+
+        it("has a .computed() property with the node's lifecycle", function () {
+            var instance;
+            var xCalls = 0,
+                yCalls = 0;
+            ko.bindingHandlers.fnHandler = function () {
+                var v = this.v = ko.observable(0);
+                instance = this;
+                this.x = this.computed(function () {
+                    xCalls++;
+                    v();  // Add a dependency.
+                    expect(this).toEqual(instance);
+                    return 'x';
+                });
+                this.y = this.computed({
+                    read: function () {
+                        yCalls++;
+                        v();
+                        expect(this).toEqual(instance);
+                        return 'y';
+                    }
+                });
+            };
+            testNode.innerHTML = '<i data-bind="fnHandler"></i>';
+            ko.applyBindings({}, testNode);
+            expect(xCalls).toEqual(1);
+            expect(yCalls).toEqual(1);
+            expect(instance.x()).toEqual('x');
+            expect(instance.y()).toEqual('y');
+            expect(xCalls).toEqual(1);
+            expect(yCalls).toEqual(1);
+            instance.v(1);
+            expect(xCalls).toEqual(2);
+            expect(yCalls).toEqual(2);
+
+            ko.cleanNode(testNode);
+            instance.v(2);
+            // Re-computations have stopped.
+            expect(xCalls).toEqual(2);
+            expect(yCalls).toEqual(2);
+        });
+
+        it("has a .subscribe property with the node's lifecycle", function () {
+            var obs = ko.observable(),
+                handlerInstance;
+            ko.bindingHandlers.fnHandler = function () {
+                handlerInstance = this;
+                this.subscribe(obs, this.cb);
+            };
+            ko.bindingHandlers.fnHandler.prototype = {
+                cb: function () {
+                    expect(this).toEqual(handlerInstance);
+                }
+            };
+            testNode.innerHTML = "<i data-bind='fnHandler'></i>";
+            ko.applyBindings({}, testNode);
+            expect(obs.getSubscriptionsCount()).toEqual(1);
+            ko.cleanNode(testNode);
+            expect(obs.getSubscriptionsCount()).toEqual(0);
+        });
+    });
 });

--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -1,3 +1,5 @@
+/* eslint semi: 0, key-spacing: 0 */
+
 describe('Binding attribute syntax', function() {
     beforeEach(jasmine.prepareTestNode);
 
@@ -648,5 +650,23 @@ describe('Binding attribute syntax', function() {
             ko.cleanNode(testNode);
             expect(obs.getSubscriptionsCount()).toEqual(0);
         });
+
+        it("addEventHandler events are cleaned up", function () {
+            var handlerInstance;
+            var fnCalls = 0;
+            function eventHandler() { return fnCalls++; }
+            ko.bindingHandlers.fnHandler = function (element) {
+                handlerInstance = this;
+                this.addEventHandler('click', eventHandler);
+            };
+            testNode.innerHTML = "<i data-bind='fnHandler'></i>";
+            ko.applyBindings({}, testNode)
+            expect(fnCalls).toEqual(0)
+            ko.utils.triggerEvent(testNode.children[0], 'click')
+            expect(fnCalls).toEqual(1)
+            ko.cleanNode(testNode)
+            ko.utils.triggerEvent(testNode.children[0], 'click')
+            expect(fnCalls).toEqual(1)
+        })
     });
 });

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -354,7 +354,9 @@
             };
 
             this.pureComputed = function handlerInstancePureComputed(evaluator) {
-                return ko.computed(evaluator, handlerInstance, {pure: true})
+                return ko.computed(evaluator, handlerInstance, {
+                    pure: true, disposeWhenNodeIsRemoved: node
+                })
             };
 
             this.subscribe = function handlerInstanceSubscription(subscribable, callback, eventType) {

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -180,7 +180,16 @@
     }
 
     function validateThatBindingIsAllowedForVirtualElements(bindingName) {
-        var validator = ko.virtualElements.allowedBindings[bindingName];
+        var bindingHandler = ko.bindingHandlers[bindingName],
+            validator;
+        if (typeof bindingHandler === 'function') {
+            validator = bindingHandler.allowVirtualElements || (
+                typeof bindingHandler.prototype === 'object' &&
+                Boolean(bindingHandler.prototype.allowVirtualElements)
+            )
+        } else {
+            validator = ko.virtualElements.allowedBindings[bindingName];
+        }
         if (!validator)
             throw new Error("The binding '" + bindingName + "' cannot be used with virtual elements")
     }
@@ -274,6 +283,105 @@
         return result;
     }
 
+    // This is called when the bindingHandler is an object (with `init` and/or
+    // `update` methods)
+    function execObjectBindingHandlerOnNode(bindingKeyAndHandler, node, getValueAccessor, allBindings, bindingContext) {
+        var handlerInitFn = bindingKeyAndHandler.handler["init"],
+            handlerUpdateFn = bindingKeyAndHandler.handler["update"],
+            bindingKey = bindingKeyAndHandler.key,
+            controlsDescendantBindings = false;
+
+        // Run init, ignoring any dependencies
+        if (typeof handlerInitFn === "function") {
+            ko.dependencyDetection.ignore(function() {
+                var initResult = handlerInitFn(node, getValueAccessor(bindingKey), allBindings, bindingContext['$data'], bindingContext);
+
+                // If this binding handler claims to control descendant bindings, make a note of this
+                if (initResult && initResult['controlsDescendantBindings']) {
+                    controlsDescendantBindings = true
+                }
+            });
+        }
+
+        // Run update in its own computed wrapper
+        if (typeof handlerUpdateFn === "function") {
+            ko.dependentObservable(
+                function() {
+                    handlerUpdateFn(node, getValueAccessor(bindingKey), allBindings, bindingContext['$data'], bindingContext);
+                },
+                null,
+                { disposeWhenNodeIsRemoved: node }
+            );
+        }
+        return controlsDescendantBindings;
+    }
+
+    // This is called when the bindingHandler is a function (or ES6 class).
+    // Node that these will work only for browsers with Object.defineProperty,
+    // i.e. IE9+.
+    function execNewBindingHandlerOnNode(bindingKeyAndHandler, node, getValueAccessor, allBindings, bindingContext) {
+        var bindingKey = bindingKeyAndHandler.key,
+            handlerParams = {
+                element: node,
+                $data: bindingContext['$data'],
+                $context: bindingContext,
+                allBindings: allBindings
+            },
+            handlerConstructor = bindingKeyAndHandler.handler,
+            handlerInstance,
+            subscriptions = [];
+
+        Object.defineProperty(handlerParams, 'value', {
+            get: function () { return getValueAccessor(bindingKey)() }
+        });
+
+        function handlerConstructorWrapper() {
+            handlerInstance = this;
+
+            // The handler instance will have properties `computed` and
+            // `subscribe`, which are almost the same as the `ko.-` equivalent
+            // except their lifecycle is limited to that of the node (i.e.
+            // they are automatically disposed).
+            this.computed = function handlerInstanceComputed(functionOrObject) {
+                var options = typeof functionOrObject === 'function' ?
+                    { read: functionOrObject, write: functionOrObject } :
+                    functionOrObject;
+                ko.utils.extend(options, {
+                    owner: handlerInstance,
+                    disposeWhenNodeIsRemoved: node
+                });
+                return ko.computed(options);
+            };
+
+            this.subscribe = function handlerInstanceSubscription(subscribable, callback, eventType) {
+                subscriptions.push(
+                    subscribable.subscribe(callback, handlerInstance, eventType)
+                );
+            };
+
+            handlerConstructor.call(this, handlerParams)
+        }
+
+        // We have to wrap the handler instance in this "subclass" because
+        // it's the only way to define this.computed/subscribe before the
+        // handlerConstructor is called, and one would expect those
+        // utilities to be available in the constructor.
+        ko.utils.extend(handlerConstructorWrapper, handlerConstructor)
+        handlerConstructorWrapper.prototype = handlerConstructor.prototype;
+        new handlerConstructorWrapper();
+
+        ko.utils.domNodeDisposal.addDisposeCallback(node, function () {
+            if (typeof handlerInstance.dispose === "function") {
+                handlerInstance.dispose.call(handlerInstance);
+            }
+            ko.utils.arrayForEach(subscriptions, function (subs) {
+                subs.dispose()
+            })
+        })
+
+        return handlerConstructor.controlsDescendantBindings || handlerInstance.controlsDescendantBindings;
+    }
+
     function applyBindingsToNodeInternal(node, sourceBindings, bindingContext, bindingContextMayDifferFromDomParentElement) {
         // Prevent multiple applyBindings calls for the same node, except when a binding value is specified
         var alreadyBound = ko.utils.domData.get(node, boundElementDomDataKey);
@@ -346,44 +454,32 @@
 
             // Go through the sorted bindings, calling init and update for each
             ko.utils.arrayForEach(orderedBindings, function(bindingKeyAndHandler) {
-                // Note that topologicalSortBindings has already filtered out any nonexistent binding handlers,
-                // so bindingKeyAndHandler.handler will always be nonnull.
-                var handlerInitFn = bindingKeyAndHandler.handler["init"],
-                    handlerUpdateFn = bindingKeyAndHandler.handler["update"],
-                    bindingKey = bindingKeyAndHandler.key;
+                var bindingKey = bindingKeyAndHandler.key,
+                    controlsDescendantBindings,
+                    execBindingFunction = typeof bindingKeyAndHandler.handler === 'function' ?
+                        execNewBindingHandlerOnNode :
+                        execObjectBindingHandlerOnNode;
 
                 if (node.nodeType === 8) {
                     validateThatBindingIsAllowedForVirtualElements(bindingKey);
                 }
 
+                // Note that topologicalSortBindings has already filtered out any nonexistent binding handlers,
+                // so bindingKeyAndHandler.handler will always be nonnull.
                 try {
-                    // Run init, ignoring any dependencies
-                    if (typeof handlerInitFn == "function") {
-                        ko.dependencyDetection.ignore(function() {
-                            var initResult = handlerInitFn(node, getValueAccessor(bindingKey), allBindings, bindingContext['$data'], bindingContext);
-
-                            // If this binding handler claims to control descendant bindings, make a note of this
-                            if (initResult && initResult['controlsDescendantBindings']) {
-                                if (bindingHandlerThatControlsDescendantBindings !== undefined)
-                                    throw new Error("Multiple bindings (" + bindingHandlerThatControlsDescendantBindings + " and " + bindingKey + ") are trying to control descendant bindings of the same element. You cannot use these bindings together on the same element.");
-                                bindingHandlerThatControlsDescendantBindings = bindingKey;
-                            }
-                        });
-                    }
-
-                    // Run update in its own computed wrapper
-                    if (typeof handlerUpdateFn == "function") {
-                        ko.dependentObservable(
-                            function() {
-                                handlerUpdateFn(node, getValueAccessor(bindingKey), allBindings, bindingContext['$data'], bindingContext);
-                            },
-                            null,
-                            { disposeWhenNodeIsRemoved: node }
-                        );
-                    }
+                    controlsDescendantBindings = execBindingFunction(
+                        bindingKeyAndHandler, node, getValueAccessor,
+                        allBindings, bindingContext)
                 } catch (ex) {
-                    ex.message = "Unable to process binding \"" + bindingKey + ": " + bindings[bindingKey] + "\"\nMessage: " + ex.message;
+                    ex.message = "Unable to process binding \"" + bindingKey +
+                        ": " + bindings[bindingKey] + "\"\nMessage: " +
+                        ex.message;
                     throw ex;
+                }
+                if (controlsDescendantBindings) {
+                    if (bindingHandlerThatControlsDescendantBindings !== undefined)
+                        throw new Error("Multiple bindings (" + bindingHandlerThatControlsDescendantBindings + " and " + bindingKey + ") are trying to control descendant bindings of the same element. You cannot use these bindings together on the same element.");
+                    bindingHandlerThatControlsDescendantBindings = bindingKey;
                 }
             });
         }

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -353,6 +353,10 @@
                 return ko.computed(options);
             };
 
+            this.pureComputed = function handlerInstancePureComputed(evaluator) {
+                return ko.computed(evaluator, handlerInstance, {pure: true})
+            };
+
             this.subscribe = function handlerInstanceSubscription(subscribable, callback, eventType) {
                 subscriptions.push(
                     subscribable.subscribe(callback, handlerInstance, eventType)

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -374,7 +374,7 @@
                 });
             };
 
-            handlerConstructor.call(this, handlerParams)
+            handlerConstructor.call(this, handlerParams);
         }
 
         // We have to wrap the handler instance in this "subclass" because

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -365,6 +365,15 @@
                 );
             };
 
+            this.addEventHandler = function addEventHandler(eventType, handler) {
+                // Register the event handler, and add it to our subscriptions
+                // for disposal when cleanNode is called- with a subscription-
+                // like API (i.e. the `dispose` property).
+                subscriptions.push({
+                    dispose: ko.utils.registerEventHandler(node, eventType, handler)
+                });
+            };
+
             handlerConstructor.call(this, handlerParams)
         }
 
@@ -381,8 +390,8 @@
             if (typeof handlerInstance.dispose === "function") {
                 handlerInstance.dispose.call(handlerInstance);
             }
-            ko.utils.arrayForEach(subscriptions, function (subs) {
-                subs.dispose();
+            ko.utils.arrayForEach(subscriptions, function (subscription) {
+                subscription.dispose();
             });
         });
 


### PR DESCRIPTION
re. #663 / #1602 ; depends on #1360.

The new binding handlers have the following properties:
1. They are function-constructors (so they can be closure-style functions, or ES6/coffeescript classes);
2. The constructor is passed a single object-parameter, with (self-explanatory) properties:
   - `value`  (created by `defineProperty` so one does not have to call an accessor)
   - `$context`
   - `$data`
   - `element`
   - `allBindings`
3. The class is instantiated for every binding found;
4. The `.dispose` for the instance, if it exists, is called when the node is removed;
5. Instances have `this.computed` and `this.subscribe`, equivalent to the `ko.*` equivalent, but their owner is set to the instance and they are cleaned up when the node is removed;
6. Are allowed in virtual elements when `allowVirtual` is truthy on either the constructor or prototype chain;
7. Control descendant bindings when `controlsContext` is truthy on the instance or the constructor.
